### PR TITLE
修复被tp玩家显示tp玩家名字为自己的bug，增加了接受tp后，显示接收成功的提示。

### DIFF
--- a/lang/en_us.yml
+++ b/lang/en_us.yml
@@ -34,6 +34,7 @@ lazybing_thb:
     request_not_found: No available teleport request found
     request_already_exists: A request for {} is available now, please request again soon
     request_create: Request created, please wait {} to respond
+    request_agree: Agree teleport request from {}
     request_declined: Declined teleport request from {}
     request_declined_requester: Request was declined by {}
     urself: Can't request to teleport to yourself

--- a/lang/zh_cn.yml
+++ b/lang/zh_cn.yml
@@ -33,7 +33,8 @@ lazybing_thb:
       hover: 点此再次请求传送至 §e{}§r
     request_not_found: 你没有待处理的传送请求
     request_already_exists: 玩家 {} 有正在处理的请求, 请稍后再试
-    request_create: 已发送传送请求至 {} 
+    request_create: 已发送传送请求至 {}
+    request_agree: 接受了 {} 的传送请求
     request_declined: 拒绝了 {} 的传送请求
     request_declined_requester: 玩家 {} 拒绝了你的请求
     urself: 禁止面对面快传

--- a/lazybing_thb/core.py
+++ b/lazybing_thb/core.py
@@ -54,6 +54,7 @@ def accept_teleport_request(source: PlayerCommandSource):
         return source.reply(rtr('tpa.request_not_found').set_color(RColor.red))
     if not PlayerOnlineList.get_instance().is_online(requester):
         return source.reply(rtr('teleport.not_online', RText(requester).set_color(RColor.yellow)))
+    source.reply(rtr("tpa.request_agree", RText(requester, RColor.yellow)))
     if config.teleport_delay >= 1:
         psi.tell(requester, rtr('tpa.countdown', str(config.teleport_delay)))
         for count in range(1, config.teleport_delay):
@@ -95,7 +96,7 @@ def request_teleport(source: PlayerCommandSource, target: str):
             target,
             _tr(
                 'text',
-                player=player_component,
+                player=source.player,
                 accept_comp=_tr('accept_comp').c(RAction.run_command, config.command_prefix.tpa_[0]).h(_tr('accept_hover')),
                 decline_comp=_tr('decline_comp').c(RAction.run_command, config.command_prefix.tpc_[0]).h(_tr('decline_hover'))
             )

--- a/lazybing_thb/core.py
+++ b/lazybing_thb/core.py
@@ -162,6 +162,8 @@ def teleport_to_home(source: PlayerCommandSource, home_site_name: str):
     home = PlayerHomeStorage.get_instance(source.player)
     with home.lock():
         site_location = home.get_home(home_site_name)
+    if site_location is None:
+        return source.reply(rtr('home.home_site_not_exists', home_site_name).set_color(RColor.red))
     teleport_to_location(source.player, site_location)
 
 


### PR DESCRIPTION
原本A玩家tpB玩家，B玩家处会显示B玩家请求传送到你的位置，请求玩家的名称不能被正确显示。现在做了响应的修改。

其次接受传送之后，接受的玩家处没有任何成功的显示，会使玩家认为没有操作成功，导致重复操作现在，做了相应的修改。