### PR TITLE
[修复] 修复引用mcdreforged文本信息时的错误以及英语翻译文本中会引发异常的错误

### DIFF
--- a/lang/en_us.yml
+++ b/lang/en_us.yml
@@ -22,7 +22,7 @@ lazybing_thb:
 
   teleport:
     after_teleport:
-      text: Teleport finished. Use {undo_command} to undo teleport
+      text: Teleport finished. §7Click here§r to undo teleport (Go back to previous location)
       hover: Click here to undo teleport
     not_online: Player {} is not online
 

--- a/lazybing_thb/storage/config.py
+++ b/lazybing_thb/storage/config.py
@@ -136,7 +136,7 @@ class Configuration(Serializable):
         except Exception as e:
             result_config = default_config.copy()
             needs_save = True
-            cls.log('server_interface.load_config_simple.failed', e)
+            cls.log('mcdreforged.server_interface.load_config_simple.failed', e)
         else:
             result_config = read_data
             if default_config is not None:
@@ -144,16 +144,16 @@ class Configuration(Serializable):
                 for key, value in default_config.items():
                     if key not in read_data:
                         result_config[key] = value
-                        cls.log('server_interface.load_config_simple.key_missed', key, value)
+                        cls.log('mcdreforged.server_interface.load_config_simple.key_missed', key, value)
                         needs_save = True
-            cls.log('server_interface.load_config_simple.succeed')
+            cls.log('mcdreforged.server_interface.load_config_simple.succeed')
 
         try:
             result_config = cls.deserialize(result_config)
         except Exception as e:
             result_config = cls.get_default()
             needs_save = True
-            cls.log('server_interface.load_config_simple.failed', e)
+            cls.log('mcdreforged.server_interface.load_config_simple.failed', e)
 
         if needs_save:
             result_config.save()


### PR DESCRIPTION
1. 修复lang/en_us.yml中teleport.after_teleport.text会引发异常的错误，将其与中文文本内容同步
2. 修复lazybing_thb/storage/config.py中引用mcdreforged.server_interface.*文本时的错误